### PR TITLE
fix(IRLCorp): Fix health import and component init

### DIFF
--- a/src/main/java/org/terasology/irlCorp/systems/MechanicalPowerToolAuthoritySystem.java
+++ b/src/main/java/org/terasology/irlCorp/systems/MechanicalPowerToolAuthoritySystem.java
@@ -35,7 +35,7 @@ import org.terasology.irlCorp.events.PowerToolUsedEvent;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.GazeAuthoritySystem;
 import org.terasology.logic.common.ActivateEvent;
-import org.terasology.logic.health.DoDamageEvent;
+import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.logic.location.LocationComponent;

--- a/src/main/java/org/terasology/irlCorp/systems/MultiBlockTankAuthoritySystem.java
+++ b/src/main/java/org/terasology/irlCorp/systems/MultiBlockTankAuthoritySystem.java
@@ -89,13 +89,17 @@ public class MultiBlockTankAuthoritySystem extends BaseComponentSystem {
                                                MultiBlockFluidTankComponent multiBlockFluidTank) {
         // Add health to the entity similarly to how block entities get health.
         if (actAsBlock.block != null && actAsBlock.block.getArchetypeBlock().isDestructible() && !entity.hasComponent(HealthComponent.class)) {
+            HealthComponent healthComponent = new HealthComponent();
+
+            // make health scale with size, use the actasblock as a starting value
+            healthComponent.maxHealth = (int) (actAsBlock.block.getArchetypeBlock().getHardness() * ((blockRegion.region.sizeX() * blockRegion.region.sizeY() * blockRegion.region.sizeZ()) / 4f));
+            healthComponent.currentHealth = healthComponent.maxHealth;
+
             // Block regen should always take the same amount of time,  regardless of its hardness
-            HealthComponent healthComponent = new HealthComponent(
-                    // make health scale with size, use the actasblock as a starting value
-                    (int) (actAsBlock.block.getArchetypeBlock().getHardness() * ((blockRegion.region.sizeX() * blockRegion.region.sizeY() * blockRegion.region.sizeZ()) / 4f)),
-                    actAsBlock.block.getArchetypeBlock().getHardness() / 4.0f,
-                    1.0f);
+            healthComponent.regenRate = actAsBlock.block.getArchetypeBlock().getHardness() / 4.0f;
+            healthComponent.waitBeforeRegen = 1.0f;
             healthComponent.destroyEntityOnNoHealth = true;
+            
             entity.addComponent(healthComponent);
         }
     }


### PR DESCRIPTION
- MovingBlock/Terasology#3677 extracts contents of engine/logic/health/ in new health module
- DoDamageEvent class now resides in Health/logic/health/event/
- HealthComponent does not require any parameters anymore, attributes need to be set explicitly after construction